### PR TITLE
Add a formula for the gds-cli

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -1,0 +1,23 @@
+class GdsCli < Formula
+  desc "CLI for common commands used by Government Digital Service staff"
+  homepage "https://github.com/alphagov/gds-cli"
+  url "git@github.com:alphagov/gds-cli",
+      :using    => :git,
+      :tag      => "v1.5.0",
+      :revision => "a4a7e01247734646f6ee391085568efb019d27da"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOOS"] = OS.mac? ? "darwin" : "linux"
+    ENV["GOARCH"] = "amd64"
+
+    system "go", "generate"
+    system "go", "build"
+    bin.install "gds-cli"
+  end
+
+  test do
+    assert_match("USAGE", shell_output("#{bin}/gds-cli"))
+  end
+end


### PR DESCRIPTION
- This installs (tested on MacOS and Linux), is useable, and passes tests and `brew audit --strict` checks.
- Pre-requisites: an SSH key, as the repo has to clone over SSH because it's private (as detailed in the README).
- People _can_ use aws-vault as their secret storage, but I've not added it as an explicit dependency here.