### PR TITLE
Fix MacOS cask tap name

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -8,7 +8,7 @@ class GdsCli < Formula
   head "git@github.com:alphagov/gds-cli.git", :using => :git
 
   depends_on "go" => :build
-  tap_name = OS.mac? ? "caskroom/cask" : "linuxbrew/extra"
+  tap_name = OS.mac? ? "homebrew/cask" : "linuxbrew/extra"
   depends_on "#{tap_name}/aws-vault"
 
   def install


### PR DESCRIPTION
- These two are functionally equivalent, and indeed on GitHub
  `caskroom/homebrew-cask` redirects to `homebrew/homebrew-cask`, but they're two separate
  taps as far as Homebrew is concerned, so users end up with two sets of
  files:

  ```
  $ brew tap | grep cask
  caskroom/cask
  homebrew/cask
  ```
- If you want to clean up 187M of disk space after this change, run `brew untap
  caskroom/cask`.