### PR TITLE
remove cask dependency

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -8,7 +8,7 @@ class GdsCli < Formula
   head "git@github.com:alphagov/gds-cli.git", :using => :git
 
   depends_on "go" => :build
-  unless OS.mac?
+  if OS.linux?
     depends_on "linuxbrew/extra/aws-vault"
   end
 

--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -8,7 +8,7 @@ class GdsCli < Formula
   head "git@github.com:alphagov/gds-cli.git", :using => :git
 
   depends_on "go" => :build
-  if !OS.mac? then
+  unless OS.mac?
     depends_on "linuxbrew/extra/aws-vault"
   end
 

--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -8,8 +8,9 @@ class GdsCli < Formula
   head "git@github.com:alphagov/gds-cli.git", :using => :git
 
   depends_on "go" => :build
-  tap_name = OS.mac? ? "homebrew/cask" : "linuxbrew/extra"
-  depends_on "#{tap_name}/aws-vault"
+  if !OS.mac? then
+    depends_on "linuxbrew/extra/aws-vault"
+  end
 
   def install
     ENV["GOOS"] = OS.mac? ? "darwin" : "linux"
@@ -18,6 +19,12 @@ class GdsCli < Formula
     system "go", "generate"
     system "go", "build"
     bin.install "gds-cli"
+  end
+
+  def caveats
+    if OS.mac?
+      return 'gds-cli depends on aws-vault being installed.  You can install it with `brew cask install aws-vault`.'
+    end
   end
 
   test do


### PR DESCRIPTION
when trying to upgrade on OS X I got

    Error: No available formula with the name "homebrew/cask/aws-vault" (dependency of alphagov/gds/gds-cli)

It seems that it's not possible to depend on casks:
https://discourse.brew.sh/t/how-to-make-formula-depend-on-cask/3557

Maybe we should just put something in the CAVEATS section?