### PR TITLE
Symlink `gds-cli` binary to `gds` during install

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -19,6 +19,7 @@ class GdsCli < Formula
     system "go", "generate"
     system "go", "build"
     bin.install "gds-cli"
+    bin.install_symlink({ "gds-cli" => "gds" })
   end
 
   def caveats
@@ -28,6 +29,6 @@ class GdsCli < Formula
   end
 
   test do
-    assert_match("USAGE", shell_output("#{bin}/gds-cli"))
+    assert_match("USAGE", shell_output("#{bin}/gds"))
   end
 end

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ A private Homebrew tap for the [gds-cli](https://github.com/alphagov/gds-cli).
 ```
 brew tap alphagov/gds
 brew install gds-cli
+gds --version
 ```
 
 or
 
 ```
 brew install alphagov/gds/gds-cli
+gds --version
 ```


### PR DESCRIPTION
This way, the utility can be accessed via both `gds` and `gds-cli` at the command line, bringing this formula in to parity with the old Makefile.