### PR TITLE
gds-cli: Run `make` instead of `go generate` and `go build`

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -16,8 +16,8 @@ class GdsCli < Formula
     ENV["GOOS"] = OS.mac? ? "darwin" : "linux"
     ENV["GOARCH"] = "amd64"
 
-    system "go", "generate"
-    system "go", "build"
+    system "make"
+
     bin.install "gds-cli"
     bin.install_symlink({ "gds-cli" => "gds" })
   end


### PR DESCRIPTION
- As per discussion in https://github.com/alphagov/gds-cli/pull/117/,
  we're switching to a common approach to building the software. Rather
  than scattering settings around, they can just be bundled into the
  Makefile which everything (this Homebrew tap, the main release pipeline,
  local development) can use.