### PR TITLE
gds-cli: Appease `brew audit --strict` and other minor style issues

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -8,9 +8,7 @@ class GdsCli < Formula
   head "git@github.com:alphagov/gds-cli.git", :using => :git
 
   depends_on "go" => :build
-  if OS.linux?
-    depends_on "linuxbrew/extra/aws-vault"
-  end
+  depends_on "linuxbrew/extra/aws-vault" if OS.linux?
 
   def install
     ENV["GOOS"] = OS.mac? ? "darwin" : "linux"
@@ -19,13 +17,13 @@ class GdsCli < Formula
     system "make"
 
     bin.install "gds-cli"
-    bin.install_symlink({ "gds-cli" => "gds" })
+    bin.install_symlink("gds-cli" => "gds")
   end
 
   def caveats
-    if OS.mac?
-      return 'gds-cli depends on aws-vault being installed.  You can install it with `brew cask install aws-vault`.'
-    end
+    return if OS.linux?
+
+    "gds-cli depends on aws-vault being installed.  You can install it with `brew cask install aws-vault`."
   end
 
   test do


### PR DESCRIPTION
$ brew audit --strict gds-cli
  alphagov/gds/gds-cli:
    * C: 22: col 25: Redundant curly braces around a hash parameter.
    * C: 27: col 7: Redundant `return` detected.
    * C: 27: col 14: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  Error: 3 problems in 1 formula detected

And use single-line if statements where possible.