### PR TITLE
govuk-cli: New formula for easy installation of `govuk connect` scripts

### DIFF
--- a/Formula/govuk-cli.rb
+++ b/Formula/govuk-cli.rb
@@ -1,0 +1,13 @@
+class GovukCli < Formula
+  desc "CLI for GOV.UK to help connecting to machines in the estate"
+  homepage "https://github.com/alphgov/govuk-cli.git"
+  # The repo doesn't tag versions (yet).
+  url "https://github.com/alphagov/govuk-cli.git"
+  version "0.0.1"
+  head "https://github.com/alphagov/govuk-cli.git"
+
+  def install
+    bin.install "bin/govuk-connect"
+    bin.install "bin/govuk"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 homebrew-gds
 ============
 
-A private Homebrew tap for the [gds-cli](https://github.com/alphagov/gds-cli).
+A private Homebrew tap for the internal GDS CLI tooling, like the [gds-cli](https://github.com/alphagov/gds-cli) and the [govuk-cli](https://github.com/alphagov/govuk-cli).
 
-## Pre-requisites
+## GDS CLI
 
-- An SSH key configured, as the repo clones over SSH.
+### Pre-requisites
 
-## Usage
+- An SSH key configured, as the gds-cli repo clones over SSH.
+
+### Usage
 
 ```
 brew tap alphagov/gds
@@ -20,4 +22,24 @@ or
 ```
 brew install alphagov/gds/gds-cli
 gds --version
+```
+
+## GOV.UK CLI
+
+### Pre-requisites
+
+- An understanding that this is the `govuk connect` tool, not the [`govukcli` tool from the govuk-aws repo](https://docs.publishing.service.gov.uk/manual/howto-ssh-to-machines-in-aws.html). Both are valid tools to use!
+
+### Usage
+
+```
+brew tap alphagov/gds
+brew install --HEAD govuk-cli
+govuk connect
+```
+
+or
+
+```
+brew install --HEAD alphagov/gds/govuk-cli
 ```


### PR DESCRIPTION
- This is almost entirely unversioned as it's just a bunch of shell
  scripts. This is unfortunate, as `brew update` and `brew upgrade`
  won't be as easy, but depending on how many changes we
  foresee for `govuk-cli`, we can do release tagging when we need to.
- Note that this is _not_ the `govukcli` tool from the `govuk-aws` repo.
  If someone wants this, they can package it themselves. But the dream is
  to be consistent with one tool with one name. :-)
- This is installable with `brew install --HEAD govuk-cli` if you want
  to get the latest changes.
- More info for "but why?" can be found in https://github.com/alphagov/govuk-guix/issues/36 and https://github.com/alphagov/gds-cli/pull/140.

Co-authored-by: Chris Baines <christopher.baines@digital.cabinet-office.gov.uk>