### PR TITLE
gds-cli: depends_on "awscli"

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -8,6 +8,7 @@ class GdsCli < Formula
   head "git@github.com:alphagov/gds-cli.git", :using => :git
 
   depends_on "go" => :build
+  depends_on "awscli"
   depends_on "linuxbrew/extra/aws-vault" if OS.linux?
 
   def install


### PR DESCRIPTION
- In https://github.com/alphagov/gds-cli/pull/152, we added "please
  `brew install awscli`" to the error message if the version is not new
  enough or it isn't installed at all.
- We can simplify our users' lives by making it an explicit runtime
  dependency here. The error message should still exist, but.