### PR TITLE
Correct spelling of alphagov

### DIFF
--- a/Formula/govuk-cli.rb
+++ b/Formula/govuk-cli.rb
@@ -1,6 +1,6 @@
 class GovukCli < Formula
   desc "CLI for GOV.UK to help connecting to machines in the estate"
-  homepage "https://github.com/alphgov/govuk-cli.git"
+  homepage "https://github.com/alphagov/govuk-cli.git"
   # The repo doesn't tag versions (yet).
   url "https://github.com/alphagov/govuk-cli.git"
   version "0.0.1"


### PR DESCRIPTION
Gimme an "a".