### PR TITLE
gds-cli: Change the binary name to `gds` and the symlink to `gds-cli`

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -17,8 +17,8 @@ class GdsCli < Formula
 
     system "make"
 
-    bin.install "gds-cli"
-    bin.install_symlink("gds-cli" => "gds")
+    bin.install "gds"
+    bin.install_symlink("gds" => "gds-cli")
   end
 
   def caveats


### PR DESCRIPTION
- Depends on https://github.com/alphagov/gds-cli/pull/160 being merged.
- This makes things consistent with [the commands in the gds-cli
  README](https://github.com/alphagov/gds-cli/blob/master/README.md).
- For users who like using `gds-cli`, the symlink is now the other way
  around: `gds` is the default.