### PR TITLE
Auto-install bash completions

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -19,6 +19,10 @@ class GdsCli < Formula
 
     bin.install "gds"
     bin.install_symlink("gds" => "gds-cli")
+
+    output = Utils.popen_read("#{bin}/gds-cli bash-completion")
+    (bash_completion/"gds-cli").write output
+    (bash_completion/"gds").write output
   end
 
   def caveats


### PR DESCRIPTION
- Assuming you've already `brew install bash-completion` and followed
  the post-install instructions, this'll work.
- Stolen the approach from the new `minikube` formula in homebrew-core.
- Closes #8 (though ZSH completions are still a stretch goal).

## Testing

- Remove the existing manual bash completion script if you've got it working.
```
export HOMEBREW_NO_AUTO_UPDATE=1
cd $(brew --repo alphagov/gds)
hub pr checkout 19
brew reinstall gds-cli
```
- Try some commands, `gds-cli a<tab>` and `gds-cli aws <tab>` are the ones I tried. Observe that they work. :crossed_fingers:

- Now `unset HOMEBREW_NO_AUTO_UPDATE` because we like auto-updating taps from master most of the time.
