### PR TITLE
Add kubeseal dependency

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -10,6 +10,7 @@ class GdsCli < Formula
   depends_on "go" => :build
   depends_on "awscli"
   depends_on "aws-vault" if OS.linux?
+  depends_on "kubeseal" => :optional
 
   def install
     ENV["GOOS"] = OS.mac? ? "darwin" : "linux"


### PR DESCRIPTION
kubeseal is required for the `seal` subcommand.