### PR TITLE
govuk-connect 0.0.2 (new formula)

### DIFF
--- a/Formula/govuk-connect.rb
+++ b/Formula/govuk-connect.rb
@@ -1,0 +1,21 @@
+class GovukConnect < Formula
+  desc "Tool for GDS staff to connect to GOV.UK infrastructure"
+  homepage "https://github.com/alphagov/govuk-connect"
+  url "https://rubygems.org/downloads/govuk-connect-0.0.2.gem"
+  sha256 "a8ffc7327b4a50b21671b03c7fb9b7c86d3faf152384f453d5f5193d2d58e359"
+
+  uses_from_macos "ruby"
+
+  def install
+    ENV["GEM_HOME"] = libexec
+
+    system "gem", "install", "--ignore-dependencies", "govuk-connect-#{version}.gem"
+    bin.install libexec/"bin/govuk-connect"
+    bin.env_script_all_files(libexec/"bin", :GEM_HOME => ENV["GEM_HOME"])
+  end
+
+  test do
+    error_message = "error: you must specify the environment"
+    assert_match(error_message, shell_output("#{bin}/govuk-connect ssh 2>&1 >/dev/null", 1))
+  end
+end


### PR DESCRIPTION
- It turns out that Ruby gems can be Homebrew formulae too, so here's
  one for govuk-connect.
- There's no automation set up yet for the gem build of this software -
  it's all manual publishing - and it'll be the same for this. But at
  least those of us with Brewfiles can have one place to declare our
  software!

----

Draft as this is entirely untested by humans. How to test:

```
gem uninstall govuk-connect
rbenv rehash
cd $(brew --repo alphagov/gds)
hub pr checkout 21
HOMEBREW_NO_AUTO_UPDATE=1 brew install govuk-connect
```