### PR TITLE
gds-cli: Automatically install ZSH completions

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -23,6 +23,10 @@ class GdsCli < Formula
     output = Utils.popen_read("#{bin}/gds-cli bash-completion")
     (bash_completion/"gds-cli").write output
     (bash_completion/"gds").write output
+
+    output = Utils.popen_read("#{bin}/gds-cli zsh-completion")
+    (zsh_completion/"_gds-cli").write output
+    (zsh_completion/"_gds").write output
   end
 
   def caveats


### PR DESCRIPTION
- This is semi-automatic: Homebrew will install them, but you'll still need [the Homebrew ZSH completion stanza](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh) in your `~/.zshrc`.
- I'd appreciate it if someone else could try it out and see if it works for you, please? It took me a while and in the end I removed Oh-My-Zsh and it's flawless now! 😕

```
cd $(brew --repo alphagov/gds)
gh pr checkout 23
HOMEBREW_NO_AUTO_UPDATE=1 brew reinstall gds-cli
gds <tab>
```