### PR TITLE
govuk-connect: Use brewed Ruby 2.6 instead of system Ruby

### DIFF
--- a/Formula/govuk-connect.rb
+++ b/Formula/govuk-connect.rb
@@ -4,7 +4,7 @@ class GovukConnect < Formula
   url "https://rubygems.org/downloads/govuk-connect-0.1.0.gem"
   sha256 "f713356586df0d4438bb5cb20d7f41d927c1d84f79419600fe94497c3067d667"
 
-  uses_from_macos "ruby"
+  depends_on "ruby"
 
   def install
     ENV["GEM_HOME"] = libexec


### PR DESCRIPTION
- On Mojave, system Ruby is 2.3.7 which is too old for govuk-connect. The `uses_from_macos` here meant "use system Ruby on macOS, and the latest Ruby on Linux" (because Linux doesn't ship with Ruby reliably).
- This meant users were getting the following error:

```
brew upgrade alphagov/gds/govuk-connect
gem
install
--ignore-dependencies
govuk-connect-0.1.0.gem
ERROR:  Error installing govuk-connect-0.1.0.gem:
	govuk-connect requires Ruby version >= 2.5.
```

----

To test:

```
cd $(brew --repo alphagov/gds)
git fetch
git checkout govuk-connect-use-brewed-ruby
HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade govuk-connect # or brew install govuk-connect
```

----

We could plausibly use `"ruby"` (2.7.x) instead of `"ruby@2.6"` to avoid another dependency, but we'll see if this fixes it for people who aren't me first.