### PR TITLE
ci: Add GitHub Actions to run `brew test-bot` for `govuk-connect`

### DIFF
--- a/.github/workflows/test-bot.yml
+++ b/.github/workflows/test-bot.yml
@@ -1,0 +1,23 @@
+name: brew test-bot
+on:
+  pull_request:
+    paths:
+      - "Formula/govuk-connect.rb"
+  push:
+    paths:
+      - "Formula/govuk-connect.rb"
+jobs:
+  test-bot:
+    runs-on: macos-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Run brew test-bot
+        run: |
+          set -e
+          brew update
+          HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/alphagov/homebrew-gds"
+          mkdir -p "$HOMEBREW_TAP_DIR"
+          rm -rf "$HOMEBREW_TAP_DIR"
+          ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+          brew test-bot govuk-connect

--- a/Formula/govuk-connect.rb
+++ b/Formula/govuk-connect.rb
@@ -4,6 +4,8 @@ class GovukConnect < Formula
   url "https://rubygems.org/downloads/govuk-connect-0.1.0.gem"
   sha256 "f713356586df0d4438bb5cb20d7f41d927c1d84f79419600fe94497c3067d667"
 
+  bottle :unneeded
+
   depends_on "ruby"
 
   def install


### PR DESCRIPTION
- There's [ongoing conversation](https://github.com/alphagov/govuk-connect/pull/21) about `brew bump-formula-pr` vs. manual bumping of the formulae.
- In that discussion, I realised that adding CI to this repo was on my todo list but I hadn't got around to it yet. This gets around to it. One of the risks of manual updates is that people don't update the `sha256` value correctly, so this will test if it still installs cleanly with the new version (and error if the SHA is incorrect). Previously this relied on a human.
- This is the boilerplate from [what we'd have got had we used `brew tap-new` upon creation](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/tap-new.rb#L52-L76). However, this is only being done for `govuk-connect` because `gds-cli` pulls from a private repo, which requires a personal access token, which we can't do because the use of GitHub Actions for secrets hasn't been approved by IA yet.
- While I'm here, set `bottle :unneeded` for `govuk-connect` otherwise `brew test-bot` might start building binaries. While that's nice, we don't have anywhere to store them, and they're unnecessary for the `govuk-connect` gem.