### PR TITLE
gds-cli: Appease `brew style` by using `Utils.safe_popen_read`

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -20,11 +20,11 @@ class GdsCli < Formula
     bin.install "gds"
     bin.install_symlink("gds" => "gds-cli")
 
-    output = Utils.popen_read("#{bin}/gds-cli bash-completion")
+    output = Utils.safe_popen_read("#{bin}/gds-cli bash-completion")
     (bash_completion/"gds-cli").write output
     (bash_completion/"gds").write output
 
-    output = Utils.popen_read("#{bin}/gds-cli zsh-completion")
+    output = Utils.safe_popen_read("#{bin}/gds-cli zsh-completion")
     (zsh_completion/"_gds-cli").write output
     (zsh_completion/"_gds").write output
   end


### PR DESCRIPTION
```
2020-06-24T09:42:48.5971030Z brew style alphagov/gds
2020-06-24T09:44:37.2818610Z == /usr/local/Homebrew/Library/Taps/alphagov/homebrew-gds/Formula/gds-cli.rb ==
2020-06-24T09:44:37.2818740Z C: 23: 14: Use Utils.safe_popen_read instead of Utils.popen_read
2020-06-24T09:44:37.2818840Z C: 27: 14: Use Utils.safe_popen_read instead of Utils.popen_read
2020-06-24T09:44:37.2818910Z
2020-06-24T09:44:37.2818990Z 2 files inspected, 2 offenses detected
```
