### PR TITLE
gds-cli: Fix HEAD builds since we changed branch names

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -5,7 +5,9 @@ class GdsCli < Formula
       :using    => :git,
       :tag      => "v2.22.0",
       :revision => "7d89fe98e8bf3f9f99ff48383311b75540c18497"
-  head "git@github.com:alphagov/gds-cli.git", :using => :git
+  head "git@github.com:alphagov/gds-cli.git",
+      :using => :git,
+      :branch => "main"
 
   depends_on "go" => :build
   depends_on "aws-vault" if OS.linux?


### PR DESCRIPTION
- We renamed `master` to `main`, so we must specify the new default branch here too. The `master` branch of `gds-cli` still exists, so Homebrew will continue to update based off that one, but it's not getting the latest updates.

Before this change:

```
➜ brew install --HEAD gds-cli
==> Installing gds-cli from alphagov/gds
==> Cloning git@github.com:alphagov/gds-cli.git
==> Checking out branch master
```

After this change:

```
➜ brew install --HEAD gds-cli
==> Cloning git@github.com:alphagov/gds-cli.git
Updating /Users/issylong/Library/Caches/Homebrew/gds-cli--git
From github.com:alphagov/gds-cli
 * branch            master     -> FETCH_HEAD
 * [new branch]      main       -> origin/main
==> Checking out branch main
```
