### PR TITLE
gds-cli: `brew cask install` => `brew install --cask` in caveats

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -34,7 +34,7 @@ class GdsCli < Formula
   def caveats
     return if OS.linux?
 
-    "gds-cli depends on aws-vault being installed.  You can install it with `brew cask install aws-vault`."
+    "gds-cli depends on aws-vault being installed.  You can install it with `brew install --cask aws-vault`."
   end
 
   test do


### PR DESCRIPTION
- Otherwise `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.` happens.

💖
