### PR TITLE
Add ykman as a dependency of gds-cli.

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -12,6 +12,7 @@ class GdsCli < Formula
   depends_on "go" => :build
   depends_on "aws-vault" if OS.linux?
   depends_on "awscli"
+  depends_on "ykman"
 
   def install
     ENV["GOOS"] = OS.mac? ? "darwin" : "linux"


### PR DESCRIPTION
gds-cli fails with a particularly unhelpful stacktrace if it tries to interact with a Yubikey without ykman installed. Adding ykman as a dependency should prevent this confusing scenario from happening to other users in future.

Alternatives considered: could make the error handling better in gds-cli and print a message complaining that ykman is missing, but that would probably be more effort for a worse result whereas this way it Just Works. ykman is tiny so there isn't really any downside to requiring it even for users who don't currently have Yubikeys.

The current user experience when ykman isn't installed is like this:

```
$ gds aws govuk-test-admin -l
panic: Unknown version is not in dotted-tri format

goroutine 1 [running]:
github.com/coreos/go-semver/semver.Must(...)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/coreos/go-semver@v0.3.0/semver/semver.go:65
github.com/coreos/go-semver/semver.New(0x1522fdb, 0xf, 0x1522fdb)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/coreos/go-semver@v0.3.0/semver/semver.go:49 +0x77
github.com/alphagov/gds-cli/pkg/cfg.YubikeyCommand(0x151fa63, 0x9, 0x0)
	/private/tmp/gds-cli-20210423-23562-b4ju9/pkg/cfg/cfg.go:245 +0x4f
github.com/alphagov/gds-cli/pkg/cfg.GetMFAFromYubi(0x151fa63, 0x9, 0x15287a0, 0x18, 0x3, 0x3, 0xc00027b1a0, 0x1c)
	/private/tmp/gds-cli-20210423-23562-b4ju9/pkg/cfg/cfg.go:270 +0xe6
github.com/alphagov/gds-cli/pkg/gds_aws.getMFA(0x0, 0x152497b, 0x12, 0x151ab84)
	/private/tmp/gds-cli-20210423-23562-b4ju9/pkg/gds_aws/aws.go:136 +0x72
github.com/alphagov/gds-cli/pkg/gds_aws.ExecVaultCmdWithEnv(0xc000354d50, 0x2f, 0xc000020033, 0x9, 0xc0001718a8, 0x8, 0x8, 0xc000171448, 0xc0001e9400, 0x1f, ...)
	/private/tmp/gds-cli-20210423-23562-b4ju9/pkg/gds_aws/aws.go:259 +0x41b
github.com/alphagov/gds-cli/pkg/gds_aws.ExecVaultCmd(0xc000354d50, 0x2f, 0xc000020033, 0x9, 0xc0001718a8, 0x8, 0x8, 0x0, 0x100d6bb, 0xc000353320, ...)
	/private/tmp/gds-cli-20210423-23562-b4ju9/pkg/gds_aws/aws.go:244 +0x106
github.com/alphagov/gds-cli/cmd.specificAccountCommand.func2(0xc00033af40, 0x8, 0xe)
	/private/tmp/gds-cli-20210423-23562-b4ju9/cmd/aws.go:145 +0x5d5
github.com/urfave/cli/v2.(*Command).Run(0xc0002d7680, 0xc00033aa80, 0x0, 0x0)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/urfave/cli/v2@v2.1.1/command.go:161 +0x4dd
github.com/urfave/cli/v2.(*App).RunAsSubcommand(0xc00012c600, 0xc00033a400, 0x0, 0x0)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:433 +0xa6d
github.com/urfave/cli/v2.(*Command).startApp(0xc00032b7a0, 0xc00033a400, 0x7ffeefbffa0c, 0x3)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/urfave/cli/v2@v2.1.1/command.go:275 +0x69b
github.com/urfave/cli/v2.(*Command).Run(0xc00032b7a0, 0xc00033a400, 0x0, 0x0)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/urfave/cli/v2@v2.1.1/command.go:91 +0x9cd
github.com/urfave/cli/v2.(*App).RunContext(0xc00012c180, 0x15bc250, 0xc000124008, 0xc00012a120, 0x6, 0x6, 0x0, 0x0)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:302 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/chrisbanks/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/urfave/cli/v2@v2.1.1/app.go:211
main.main()
	/private/tmp/gds-cli-20210423-23562-b4ju9/main.go:50 +0xa53
```

Tested:

```
$ brew reinstall --build-from-source --formula Formula/gds-cli.rb 
==> Downloading https://ghcr.io/v2/homebrew/core/ykman/manifests/4.0.2
Already downloaded: /Users/chrisbanks/Library/Caches/Homebrew/downloads/85bc6f92f934109e420a6b2876fe21b48a3d0b120d974ad4b6f26cf1f629943e--ykman-4.0.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/ykman/blobs/sha256:7679ab9aa2fa8c4f5a220849ef43e135
Already downloaded: /Users/chrisbanks/Library/Caches/Homebrew/downloads/e0c961e8c02ae39b96b8572fc8cdfbe6fb3151d7de0fb5d280b204d958f84b60--ykman--4.0.2.catalina.bottle.tar.gz
==> Cloning git@github.com:alphagov/gds-cli.git
Updating /Users/chrisbanks/Library/Caches/Homebrew/gds-cli--git
==> Checking out tag v4.0.0
HEAD is now at f5b54ca Merge pull request #322 from alphagov/add-new-roles
HEAD is now at f5b54ca Merge pull request #322 from alphagov/add-new-roles
==> Reinstalling gds-cli 
==> Installing dependencies for gds-cli: ykman
==> Installing gds-cli dependency: ykman
==> Pouring ykman--4.0.2.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/ykman/4.0.2: 927 files, 12.3MB
==> Installing gds-cli
==> make
==> Caveats
gds-cli depends on aws-vault being installed.  You can install it with `brew install --cask aws-vault`.

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/gds-cli/4.0.0: 9 files, 11.2MB, built in 5 seconds
==> Caveats
==> gds-cli
gds-cli depends on aws-vault being installed.  You can install it with `brew install --cask aws-vault`.

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
$ gds aws govuk-test-admin -l
Touch your YubiKey...
```