### PR TITLE
Remove `bottle :unneeded` to silence deprecation warning.

### DIFF
--- a/Formula/govuk-connect.rb
+++ b/Formula/govuk-connect.rb
@@ -4,8 +4,6 @@ class GovukConnect < Formula
   url "https://rubygems.org/downloads/govuk-connect-0.5.0.gem"
   sha256 "b983608ed5b324fd344bec20217a65cc29ecfcbb9066bb8199e682150ba9ab3b"
 
-  bottle :unneeded
-
   depends_on "ruby"
 
   def install


### PR DESCRIPTION
This prevents Homebrew from printing a deprecation warning on every invocation of `brew` (or at least every invocation of certain `brew` commands).

Tested by making the same change locally with `brew edit`:

```
$ brew cleanup
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the alphagov/gds tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/alphagov/homebrew-gds/Formula/govuk-connect.rb:7
$
$ brew edit govuk-connect
Editing /usr/local/Homebrew/Library/Taps/alphagov/homebrew-gds/Formula/govuk-connect.rb
$
$ brew cleanup
$ 
```

`bottle :unneeded` has been a no-op for some time now, so all we need to do here is delete it.

Fixes #40.