### PR TITLE
Fix completion function generation

### DIFF
--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -23,13 +23,17 @@ class GdsCli < Formula
     bin.install "gds"
     bin.install_symlink("gds" => "gds-cli")
 
-    output = Utils.safe_popen_read("#{bin}/gds-cli", "bash-completion")
-    (bash_completion/"gds-cli").write output
+    # Completion for `gds`
+    output = Utils.safe_popen_read("#{bin}/gds", "shell-completion", "bash")
     (bash_completion/"gds").write output
-
-    output = Utils.safe_popen_read("#{bin}/gds-cli", "zsh-completion")
-    (zsh_completion/"_gds-cli").write output
+    output = Utils.safe_popen_read("#{bin}/gds", "shell-completion", "zsh")
     (zsh_completion/"_gds").write output
+
+    # Completion for `gds-cli`
+    output = Utils.safe_popen_read("#{bin}/gds-cli", "shell-completion", "bash")
+    (bash_completion/"gds-cli").write output
+    output = Utils.safe_popen_read("#{bin}/gds-cli", "shell-completion", "zsh")
+    (zsh_completion/"_gds-cli").write output
   end
 
   def caveats


### PR DESCRIPTION
The completion functions for gds-cli are associated with the
binaries using the filename of the called binary. ie. if you
renamed 'gds' to 'umbrella', the generated function would be
associated with the binary 'umbrella', and would therefore not
trigger when `gds` was called.

We have been associating both `_gds` and `_gds-cli` with `gds`,
and so they are not correctly associated.

Now, create completion functions for `gds` by calling the binary,
and functions for `gds-cli` by calling the symlink.

Additionally, the individual `$SHELL-completion` functions have
been deprecated in alphagov/gds-cli#601, so I have updated the
syntax in the formula.
