### PR TITLE
Make aws-vault mandatory dependency for gds cli

### DIFF
--- a/.github/workflows/test-bot.yml
+++ b/.github/workflows/test-bot.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           set -e
           brew update
-          HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/alphagov/homebrew-gds"
+          HOMEBREW_TAP_DIR="$(brew --prefix)/Library/Taps/alphagov/homebrew-gds"
           mkdir -p "$HOMEBREW_TAP_DIR"
           rm -rf "$HOMEBREW_TAP_DIR"
           ln -s "$PWD" "$HOMEBREW_TAP_DIR"

--- a/Formula/gds-cli.rb
+++ b/Formula/gds-cli.rb
@@ -10,7 +10,7 @@ class GdsCli < Formula
       branch: "main"
 
   depends_on "go" => :build
-  depends_on "aws-vault" if OS.linux?
+  depends_on "aws-vault"
   depends_on "awscli"
   depends_on "ykman"
 
@@ -34,12 +34,6 @@ class GdsCli < Formula
     (bash_completion/"gds-cli").write output
     output = Utils.safe_popen_read("#{bin}/gds-cli", "shell-completion", "zsh")
     (zsh_completion/"_gds-cli").write output
-  end
-
-  def caveats
-    return if OS.linux?
-
-    "gds-cli depends on aws-vault being installed.  You can install it with `brew install --cask aws-vault`."
   end
 
   test do


### PR DESCRIPTION
This is a sensible option since the tool requires `aws-vault` for most of its operations. It reduces the instructions needed, and it is one less tool to install for new users.

Added benefits from having it integrated with `brew`:
* Installs the latest version automatically (no need to worry about >=v6 requirement)
* Keeps in line with how the rest of the dependencies are handled, e.g. `ykman`

CI error note: I don't think it is worth spending time fixing errors that were not introduced with this PR.